### PR TITLE
ci: try to find the correct site-packages path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           description: "Set up environment."
           command: |
             pip install -r requirements.txt -r test_requirements.txt | cat; test ${PIPESTATUS[0]} -eq 0
-            echo "import coverage; coverage.process_startup()" > `python -c "import sys; print([x for x in sys.path if x.find('site-packages') != -1][0] + '/coverage-all-the-things.pth')"`
+            echo "import coverage; coverage.process_startup()" > `python -c "import coverage; from pathlib import Path; print(Path.joinpath(Path(coverage.__path__[0]).parent, 'coverage-all-the-things.pth'))"`
       - run:
           description: "Run tests."
           command: |


### PR DESCRIPTION
- try to deal with the fact that there may be multiple site-packages paths, of which the first one might not be the one with 'coverage'